### PR TITLE
Edit path argument to be more opinionated

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -41,21 +41,16 @@ Render to TIFF any Google Static Maps (GSM) image
 		// Get flags
 		zoom, _ := cmd.Flags().GetInt("zoom")
 		size, _ := cmd.Flags().GetIntSlice("size")
-		pngPath, _ := cmd.Flags().GetString("pngPath")
-		tiffPath, _ := cmd.Flags().GetString("tiffPath")
-		jsonPath, _ := cmd.Flags().GetString("jsonPath")
+		path, _ := cmd.Flags().GetString("path")
 
-		services.RunPipeline(coordinate, zoom, size, pngPath, tiffPath, jsonPath)
+		services.RunPipeline(coordinate, zoom, size, path)
 	},
 }
 
 func init() {
 	rootCmd.PersistentFlags().IntP("zoom", "z", int(16), "zoom level")
 	rootCmd.PersistentFlags().IntSliceP("size", "s", []int{400, 400}, "image size in pixels {L},{W}")
-	rootCmd.PersistentFlags().String("pngPath", "tiffany.out/png/", "path to save GSM images in PNG")
-	rootCmd.PersistentFlags().String("tiffPath", "tiffany.out/tiff/", "path to save GSM images in TIFF")
-	rootCmd.PersistentFlags().String("jsonPath", "tiffany.out/json/", "path to save GeoJSON labels")
-	rootCmd.MarkFlagRequired("coordinate")
+	rootCmd.PersistentFlags().String("path", "tiffany.out/", "path to save output artifacts")
 }
 
 // Execute runs the root command

--- a/pkg/services/pipelines.go
+++ b/pkg/services/pipelines.go
@@ -9,10 +9,10 @@ import (
 )
 
 // RunPipeline executes the whole download and georeference tasks for a single coordinate
-func RunPipeline(coordinate []string, zoom int, size []int, pngPath string, tiffPath string, jsonPath string) {
+func RunPipeline(coordinate []string, zoom int, size []int, path string) {
 	client := auth.GetStaticMapsClient()
 	gsmImage := GetGSMImage(client, coordinate, zoom, size)
 	pngFileName := fmt.Sprintf("%s-%s-%d-%dx%d.png", coordinate[0], coordinate[1], zoom, size[0], size[1])
-	SaveImagePNG(gsmImage, pngPath, pngFileName)
+	SaveImagePNG(gsmImage, fmt.Sprintf("%spng/", path), pngFileName)
 
 }


### PR DESCRIPTION
Instead of specifying paths to where the json, tiff, and png output artifacts
are saved, we just have one command for specifiying the parent directory.