### PR TITLE
Update format of output filenames

### DIFF
--- a/cmd/handlers.go
+++ b/cmd/handlers.go
@@ -122,7 +122,7 @@ func RunPipeline(coordinate []string, zoom int, size []int, path string, noRef b
 	const geoSubDir string = "tif"
 
 	// Create filenames for output artifacts
-	fnameFormat := fmt.Sprintf("%s-%s-%d-%dx%d", coordinate[0], coordinate[1], zoom, size[0], size[1])
+	fnameFormat := fmt.Sprintf("%s_%s_%d_%dx%d", coordinate[0], coordinate[1], zoom, size[0], size[1])
 	pngPath := filepath.Join(path, gsmSubDir, fnameFormat+".png")
 	tifPath := filepath.Join(path, geoSubDir, fnameFormat+".tiff")
 


### PR DESCRIPTION
Underscore is used to account for cases where coordinates are negative