### PR TITLE
Fix 'too many open files' error (#25)

### DIFF
--- a/cmd/pipelines.go
+++ b/cmd/pipelines.go
@@ -96,10 +96,12 @@ func GeoReferenceImage(coordinate []string, size []int, zoom int, inpath string,
 
 	// Read source image and its driver
 	srcDataset, _ := gdal.Open(inpath, gdal.ReadOnly)
+	defer srcDataset.Close()
 	driver, _ := gdal.GetDriverByName("GTiff")
 
 	// Open destination dataset
 	dstDataset := driver.CreateCopy(outpath, srcDataset, 0, nil, nil, nil)
+	defer dstDataset.Close()
 	dstDataset.SetGeoTransform([6]float64{upperLeftX, gsdResolution, 0, upperLeftY, 0, -gsdResolution})
 
 	// Get raster projection
@@ -108,9 +110,6 @@ func GeoReferenceImage(coordinate []string, size []int, zoom int, inpath string,
 	destWKT, _ := srs.ToWKT()
 
 	dstDataset.SetProjection(destWKT)
-
-	defer dstDataset.Close()
-	defer srcDataset.Close()
 }
 
 // GetGSMImage downloads a single static maps image given a client and set of


### PR DESCRIPTION
It's just a matter of `defer` placement. The file is not being closed
when too many operations are being done. It's better to call the defer
function right away after opening or creating the file.

Signed-off-by: Lester James V. Miranda <lj@thinkingmachin.es>